### PR TITLE
Windows Path separators

### DIFF
--- a/src/commands/email-watch.ts
+++ b/src/commands/email-watch.ts
@@ -6,6 +6,7 @@ import logUpdate from "log-update";
 import {EmailTemplate, FusionAuthClient} from "@fusionauth/typescript-client";
 import {readFile, realpath} from "fs/promises";
 import chalk from "chalk";
+import nodePath from "path";
 import logSymbols from "log-symbols";
 import {ConditionalKeys} from "type-fest";
 import {apiKeyOption, hostOption} from "../options.js";
@@ -60,7 +61,7 @@ export const emailWatch = new Command('email:watch')
 
                     const relativePath = absolutePath.substring(absoluteInput.length + 1);
 
-                    const parts = relativePath.split('/');
+                    const parts = relativePath.split(nodePath.sep);
 
                     let emailTemplateId, locale, fileName;
                     if (parts.length === 2) {

--- a/src/commands/email-watch.ts
+++ b/src/commands/email-watch.ts
@@ -6,7 +6,7 @@ import logUpdate from "log-update";
 import {EmailTemplate, FusionAuthClient} from "@fusionauth/typescript-client";
 import {readFile, realpath} from "fs/promises";
 import chalk from "chalk";
-import nodePath from "path";
+import {sep as pathSeparator} from "path";
 import logSymbols from "log-symbols";
 import {ConditionalKeys} from "type-fest";
 import {apiKeyOption, hostOption} from "../options.js";
@@ -61,7 +61,7 @@ export const emailWatch = new Command('email:watch')
 
                     const relativePath = absolutePath.substring(absoluteInput.length + 1);
 
-                    const parts = relativePath.split(nodePath.sep);
+                    const parts = relativePath.split(pathSeparator);
 
                     let emailTemplateId, locale, fileName;
                     if (parts.length === 2) {

--- a/src/commands/theme-watch.ts
+++ b/src/commands/theme-watch.ts
@@ -8,7 +8,7 @@ import logUpdate from "log-update";
 import logSymbols from "log-symbols";
 import chalk from "chalk";
 import {apiKeyOption, hostOption, themeTypeOption} from "../options.js";
-import nodePath from 'path';
+import {basename} from 'path';
 
 // To prevent multiple uploads from happening at once, we use a queue
 const q = new Queue({autostart: true, concurrency: 1});
@@ -64,7 +64,7 @@ export const themeWatch = new Command('theme:watch')
                     }
 
                     if (path.endsWith('.ftl')) {
-                        const name = nodePath.basename(path).replace('.ftl', '');
+                        const name = basename(path).replace('.ftl', '');
                         theme.templates = {[name!]: content};
                     }
 

--- a/src/commands/theme-watch.ts
+++ b/src/commands/theme-watch.ts
@@ -8,6 +8,7 @@ import logUpdate from "log-update";
 import logSymbols from "log-symbols";
 import chalk from "chalk";
 import {apiKeyOption, hostOption, themeTypeOption} from "../options.js";
+import nodePath from 'path';
 
 // To prevent multiple uploads from happening at once, we use a queue
 const q = new Queue({autostart: true, concurrency: 1});
@@ -63,7 +64,7 @@ export const themeWatch = new Command('theme:watch')
                     }
 
                     if (path.endsWith('.ftl')) {
-                        const name = path.split('/').pop()?.replace('.ftl', '');
+                        const name = nodePath.basename(path).replace('.ftl', '');
                         theme.templates = {[name!]: content};
                     }
 


### PR DESCRIPTION
* fixed path separators when resolving theme's template name and email's details by using `path.sep` for separator resolving and `path.basename` for resolving filename of the file in theme watch 