### PR TITLE
Replace deprecated import assertion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,15 @@
 #! /usr/bin/env -S node --no-warnings=ExperimentalWarning
-
-import figlet from 'figlet';
-import {Command} from '@commander-js/extra-typings';
+import * as fs from 'node:fs';
+import { Command } from '@commander-js/extra-typings';
 import chalk from 'chalk';
+import figlet from 'figlet';
 import * as commands from './commands/index.js';
-// @ts-ignore
-import pkg from '../package.json' with { type: 'json' };
-
 const fusionString = figlet.textSync('Fusion').split('\n');
 const authString = figlet.textSync('Auth').split('\n');
-
 fusionString.forEach((line, i) => {
-    console.log(chalk.white(line) + chalk.hex('#F58320')(authString[i]));
+  console.log(chalk.white(line) + chalk.hex('#F58320')(authString[i]));
 });
-
 const program = new Command();
-program
-    .name('@fusionauth/cli')
-    .description('CLI for FusionAuth')
-    .version(pkg.version);
-
-Object.values(commands).forEach(command => program.addCommand(command));
-
+program.name('@fusionauth/cli').description('CLI for FusionAuth');
+Object.values(commands).forEach((command) => program.addCommand(command));
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {Command} from '@commander-js/extra-typings';
 import chalk from 'chalk';
 import * as commands from './commands/index.js';
 // @ts-ignore
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 const fusionString = figlet.textSync('Fusion').split('\n');
 const authString = figlet.textSync('Auth').split('\n');


### PR DESCRIPTION
[import-assertions](https://nodejs.org/docs/latest-v17.x/api/esm.html#import-assertions) have been deprecated in favor of [import-attributes](https://nodejs.org/docs/latest-v22.x/api/esm.html#import-attributes). 

From Node.js v22, using import attributes will be mandatory.