### PR TITLE
Removes tenantId as that's been removed in 1.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/cli",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "FusionAuth CLI",
   "main": "dist/index.js",
   "files": [

--- a/src/resources/kickstart/kickstart.json
+++ b/src/resources/kickstart/kickstart.json
@@ -22,7 +22,9 @@
           "algorithm": "RS256",
           "name": "For example app",
           "length": 2048
-        }
+        },
+        "tenantId": "#{defaultTenantId}"
+
       }
     },
     {

--- a/src/resources/kickstart/kickstart.json
+++ b/src/resources/kickstart/kickstart.json
@@ -17,7 +17,6 @@
     {
       "method": "POST",
       "url": "/api/key/generate/#{asymmetricKeyId}",
-      "tenantId": "#{defaultTenantId}",
       "body": {
         "key": {
           "algorithm": "RS256",

--- a/src/resources/kickstart/kickstart.json
+++ b/src/resources/kickstart/kickstart.json
@@ -22,9 +22,7 @@
           "algorithm": "RS256",
           "name": "For example app",
           "length": 2048
-        },
-        "tenantId": "#{defaultTenantId}"
-
+        }
       }
     },
     {


### PR DESCRIPTION
As of v1.65, API Key generation no longer supports`tenantId`. This removes the Kickstart tenantId property from the API call